### PR TITLE
Define global alias in Vite config

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,7 @@ import vue from '@vitejs/plugin-vue'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  define: {
+    global: 'globalThis',
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vite to replace the global identifier with globalThis for compatibility

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_b_68cced6439b08328a3758d5dc6f53933